### PR TITLE
Enable docker

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -9,3 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -23,7 +23,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest-xl
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,0 +1,122 @@
+name: Docker
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+on:
+  schedule:
+    - cron: "27 0 * * *"
+  push:
+    branches: ["main"]
+    # Publish semver tags as releases.
+    tags: ["v*.*.*"]
+  pull_request:
+    branches: ["main"]
+
+env:
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
+  # github.repository as <account>/<repo>
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest-xl
+    permissions:
+      contents: read
+      packages: write
+      # This is used to complete the identity challenge
+      # with sigstore/fulcio when running outside of PRs.
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Install the cosign tool except on PR
+      # https://github.com/sigstore/cosign-installer
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@59acb6260d9c0ba8f4a2f9d9b48431a222b68e20 #v3.5.0
+        with:
+          cosign-release: "v2.2.4"
+
+      # Set up BuildKit Docker container builder to be able to build
+      # multi-platform images and export cache
+      # https://github.com/docker/setup-buildx-action
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Extract metadata (tags, labels) for Docker
+      # https://github.com/docker/metadata-action
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+            type=edge
+            # Custom rule to prevent pre-releases from getting latest tag
+            type=raw,value=latest,enable=${{ github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+
+      - name: Go Build Cache for Docker
+        uses: actions/cache@v4
+        with:
+          path: go-build-cache
+          key: ${{ runner.os }}-go-build-cache-${{ hashFiles('**/go.sum') }}
+
+      - name: Inject go-build-cache
+        uses: reproducible-containers/buildkit-cache-dance@4b2444fec0c0fb9dbf175a96c094720a692ef810 # v2.1.4
+        with:
+          cache-source: go-build-cache
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+        with:
+          context: .
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            VERSION=${{ github.ref_name }}
+
+      # Sign the resulting Docker image digest except on PRs.
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+ARG VERSION="dev"
+
+FROM golang:1.24.2 AS build
+# allow this step access to build arg
+ARG VERSION
+# Set the working directory
+WORKDIR /build
+
+RUN go env -w GOMODCACHE=/root/.cache/go-build
+
+# Install dependencies
+COPY go.mod go.sum ./
+RUN --mount=type=cache,target=/root/.cache/go-build go mod download
+
+COPY . ./
+# Build the server
+RUN --mount=type=cache,target=/root/.cache/go-build CGO_ENABLED=0 make go-build
+
+# Make a stage to run the app
+FROM gcr.io/distroless/base-debian12
+# Set the working directory
+WORKDIR /
+# Copy the binary from the build stage
+COPY --from=build /build/bin/myshoes-mcp-server .
+# Command to run the server
+CMD ["/myshoes-mcp-server", "stdio"]

--- a/Makefile
+++ b/Makefile
@@ -28,3 +28,7 @@ go-mod: ## Update go.mod and go.sum
 .PHONY: go-test
 go-test: ## Exec test
 	go test -ldflags="$(BUILD_LDFLAGS)" -cover ./...
+
+.PHONY: docker-build
+docker-build: bin/myshoes-mcp-server ## Build docker image
+	docker build -t myshoes-mcp-server:latest .


### PR DESCRIPTION
This pull request introduces Docker support for the project, including configuration for automated builds, a Dockerfile for building and running the application, and updates to the Makefile to include Docker-related tasks. The changes are grouped into three themes: Dependabot configuration, GitHub Actions workflow, and Docker integration.

### Dependabot Configuration Updates
* Added Docker as a package ecosystem to the Dependabot configuration to enable automated dependency updates for Dockerfiles. (`.github/dependabot.yaml`, [.github/dependabot.yamlR12-R15](diffhunk://#diff-ee0c08340ace9ac3ce3c78e2377968bca2376b8bfd9a7a48d96515f5490a902cR12-R15))

### GitHub Actions Workflow for Docker
* Introduced a new GitHub Actions workflow (`docker-publish.yaml`) to automate Docker image builds and publishing. This includes support for multi-platform images, metadata extraction, caching, and signing of published images. (`.github/workflows/docker-publish.yaml`, [.github/workflows/docker-publish.yamlR1-R122](diffhunk://#diff-7df6fde7cd40d060002a40cd3e8e75083d6e02126efac835930e66eee5c4dd8dR1-R122))

### Docker Integration
* Added a `Dockerfile` to build and run the application. The Dockerfile uses a multi-stage build process with Go for compiling the application and a minimal base image for running it. (`Dockerfile`, [DockerfileR1-R26](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R1-R26))
* Updated the `Makefile` to include a `docker-build` target for building the Docker image locally. (`Makefile`, [MakefileR31-R34](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R31-R34))