### PR TITLE
Add setup-qemu-action

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -43,6 +43,11 @@ jobs:
         with:
           cosign-release: "v2.2.4"
 
+      # Set up QEMU for multi-platform builds
+      # https://github.com/docker/setup-qemu-action
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@68827325e0b33c7199eb31dd4e31fbe9023e06e3 # v3.0.0
+
       # Set up BuildKit Docker container builder to be able to build
       # multi-platform images and export cache
       # https://github.com/docker/setup-buildx-action


### PR DESCRIPTION
This pull request includes a small addition to the `.github/workflows/docker-publish.yaml` file. It sets up QEMU for multi-platform builds using the `docker/setup-qemu-action` GitHub Action.