### PR TITLE
Disable scheduling build

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -6,8 +6,6 @@ name: Docker
 # documentation.
 
 on:
-  schedule:
-    - cron: "27 0 * * *"
   push:
     branches: ["main"]
     # Publish semver tags as releases.


### PR DESCRIPTION
This pull request modifies the `.github/workflows/docker-publish.yaml` file to adjust the triggers for the Docker publishing workflow. The scheduled trigger has been removed, leaving only the push trigger for the `main` branch and semver tags.

Key change:

* [`.github/workflows/docker-publish.yaml`](diffhunk://#diff-7df6fde7cd40d060002a40cd3e8e75083d6e02126efac835930e66eee5c4dd8dL9-L10): Removed the scheduled trigger (`schedule: cron`) for the Docker publishing workflow, simplifying the workflow to only trigger on pushes to the `main` branch or semver tags.